### PR TITLE
dev

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ local_ip=$(hostname -I | awk '{print $1}')
 
 # 日志输出函数
 log() {
-    echo "[$(date +"%F %T")] $1"
+    echo -e "[$(date +"%F %T")] $1"
 }
 
 # 系统更新和安装必要软件

--- a/watch/update_mihomo.sh
+++ b/watch/update_mihomo.sh
@@ -2,7 +2,6 @@
 
 # 颜色变量
 yellow="\033[33m"
-green_text="\033[32m"
 reset="\033[0m"
 
 # 日志函数
@@ -26,10 +25,64 @@ detect_architecture() {
     esac
 }
 
+# 检查 AMD64 架构是否支持 v3 指令集 (x86-64-v3)
+check_amd64_v3_support() {
+    local arch
+    arch=$(detect_architecture)
+
+    # 只有 AMD64 架构才需要检查 v3 支持
+    if [ "$arch" != "amd64" ]; then
+        return 1
+    fi
+
+    # v3 要求的指令集
+    local required_flags=("sse4_2" "avx" "avx2" "bmi1" "bmi2" "fma" "abm")
+
+    # 获取 CPU flags
+    local cpu_flags
+    cpu_flags=$(grep -m1 -o -E 'sse4_2|avx2|avx|bmi1|bmi2|fma|abm' /proc/cpuinfo | sort -u)
+
+    # 检查每一个必须的指令集
+    for flag in "${required_flags[@]}"; do
+        if ! grep -qw "$flag" <<< "$cpu_flags"; then
+            log "AMD64 架构缺少指令集: $flag → 不支持 v3"
+            return 1
+        fi
+    done
+
+    log "检测到 AMD64 架构支持完整 v3 指令集"
+    return 0
+}
+
+# 加载环境变量
+load_env() {
+    local env_file="/mssb/mssb.env"
+    if [ -f "$env_file" ]; then
+        # shellcheck source=/mssb/mssb.env
+        source "$env_file"
+        log "已加载环境变量文件 $env_file"
+    else
+        log "未找到环境变量文件 $env_file，使用默认配置"
+        amd64v3_enabled="false"
+    fi
+}
+
 # 安装 Mihomo 核心
 mihomo_install() {
+    # 加载环境变量
+    load_env
+    
     arch=$(detect_architecture)
-    download_url="https://github.com/herozmy/StoreHouse/releases/download/mihomo/mihomo-meta-linux-${arch}.tar.gz"
+    
+    # 根据 v3 支持情况选择下载链接
+    if [ "$amd64v3_enabled" = "true" ] && check_amd64_v3_support; then
+        download_url="https://github.com/baozaodetudou/mssb/releases/download/mihomo/mihomo-meta-linux-amd64v3.tar.gz"
+        log "使用 AMD64 v3 优化版本"
+    else
+        download_url="https://github.com/baozaodetudou/mssb/releases/download/mihomo/mihomo-meta-linux-${arch}.tar.gz"
+        log "使用标准版本"
+    fi
+    
     log "开始下载 Mihomo 核心：$download_url"
 
     if ! wget -O /tmp/mihomo.tar.gz "$download_url"; then
@@ -46,7 +99,10 @@ mihomo_install() {
 
     chmod +x /usr/local/bin/mihomo || log "警告：未能设置 Mihomo 执行权限"
     rm -f /tmp/mihomo.tar.gz
-    log "Mihomo 安装完成，临时文件已清理"
+    
+    # 显示安装完成的版本信息
+    new_version=$(/usr/local/bin/mihomo -v 2>/dev/null | head -n1 | awk '{print $2}' || echo "未知版本")
+    log "Mihomo 安装完成，版本：$new_version，临时文件已清理"
 }
 
 # 主逻辑

--- a/watch/update_mosdns.sh
+++ b/watch/update_mosdns.sh
@@ -1,72 +1,125 @@
 #!/bin/bash
-# 定义颜色变量
+
+# 颜色变量
 yellow="\033[33m"
 reset="\033[0m"
 
-# 记录当前时间
-echo "[$(date)] 开始更新 MosDNS..."
+# 日志函数
+log() {
+    echo -e "[$(date +'%F %T')] ${yellow}$*${reset}"
+}
 
-# 获取系统架构
-# 检测系统 CPU 架构，并返回标准格式（适用于多数构建/下载脚本）
+# 检测系统架构
 detect_architecture() {
     case "$(uname -m)" in
-        x86_64)     echo "amd64" ;;    # 64 位 x86 架构
-        aarch64)    echo "arm64" ;;    # 64 位 ARM 架构
-        armv7l)     echo "armv7" ;;    # 32 位 ARM 架构（常见于树莓派）
-        armhf)      echo "armhf" ;;    # ARM 硬浮点
-        s390x)      echo "s390x" ;;    # IBM 架构
-        i386|i686)  echo "386" ;;      # 32 位 x86 架构
+        x86_64)     echo "amd64" ;;
+        aarch64)    echo "arm64" ;;
+        armv7l)     echo "armv7" ;;
+        armhf)      echo "armhf" ;;
+        s390x)      echo "s390x" ;;
+        i386|i686)  echo "386" ;;
         *)
-            echo -e "${yellow}不支持的CPU架构: $(uname -m)${reset}"
+            log "不支持的CPU架构: $(uname -m)"
             exit 1
             ;;
     esac
 }
 
-#LATEST_RELEASE_URL="https://github.com/IrineSistiana/mosdns/releases/latest"
-#LATEST_VERSION=$(curl -sL -o /dev/null -w %{url_effective} $LATEST_RELEASE_URL | awk -F '/' '{print $NF}')
-#MOSDNS_URL="https://github.com/IrineSistiana/mosdns/releases/download/${LATEST_VERSION}/mosdns-linux-${TARGETARCH}.zip"
-arch=$(detect_architecture)
-MOSDNS_URL="https://github.com/herozmy/StoreHouse/releases/download/mosdns/mosdns-linux-${arch}.zip"
+# 检查 AMD64 架构是否支持 v3 指令集 (x86-64-v3)
+check_amd64_v3_support() {
+    local arch
+    arch=$(detect_architecture)
 
-# 下载最新的 MosDNS
-echo "[$(date)] 正在从 $MOSDNS_URL 下载 MosDNS..."
-if curl -L -o /tmp/mosdns.zip $MOSDNS_URL; then
-    echo "[$(date)] MosDNS 下载成功。"
-else
-    echo "[$(date)] MosDNS 下载失败，请检查网络连接或 URL 是否正确。"
-    exit 1
-fi
+    # 只有 AMD64 架构才需要检查 v3 支持
+    if [ "$arch" != "amd64" ]; then
+        return 1
+    fi
 
-# 解压并安装 MosDNS
-echo "[$(date)] 正在解压 MosDNS..."
-if unzip -o /tmp/mosdns.zip -d /usr/local/bin; then
-    echo "[$(date)] MosDNS 解压成功。"
-else
-    echo "[$(date)] MosDNS 解压失败，请检查压缩包是否正确。"
-    exit 1
-fi
+    # v3 要求的指令集
+    local required_flags=("sse4_2" "avx" "avx2" "bmi1" "bmi2" "fma" "abm")
 
-# 设置执行权限
-echo "[$(date)] 正在设置 MosDNS 可执行权限..."
-if chmod +x /usr/local/bin/mosdns; then
-    echo "[$(date)] 设置执行权限成功。"
+    # 获取 CPU flags
+    local cpu_flags
+    cpu_flags=$(grep -m1 -o -E 'sse4_2|avx2|avx|bmi1|bmi2|fma|abm' /proc/cpuinfo | sort -u)
+
+    # 检查每一个必须的指令集
+    for flag in "${required_flags[@]}"; do
+        if ! grep -qw "$flag" <<< "$cpu_flags"; then
+            log "AMD64 架构缺少指令集: $flag → 不支持 v3"
+            return 1
+        fi
+    done
+
+    log "检测到 AMD64 架构支持完整 v3 指令集"
+    return 0
+}
+
+# 加载环境变量
+load_env() {
+    local env_file="/mssb/mssb.env"
+    if [ -f "$env_file" ]; then
+        # shellcheck source=/mssb/mssb.env
+        source "$env_file"
+        log "已加载环境变量文件 $env_file"
+    else
+        log "未找到环境变量文件 $env_file，使用默认配置"
+        amd64v3_enabled="false"
+    fi
+}
+
+# 安装 MosDNS 核心
+mosdns_install() {
+    # 加载环境变量
+    load_env
+    
+    arch=$(detect_architecture)
+    
+    # 根据 v3 支持情况选择下载链接
+    if [ "$amd64v3_enabled" = "true" ] && check_amd64_v3_support; then
+        MOSDNS_URL="https://github.com/baozaodetudou/mssb/releases/download/mosdns/mosdns-linux-amd64-v3.zip"
+        log "使用 AMD64 v3 优化版本"
+    else
+        MOSDNS_URL="https://github.com/baozaodetudou/mssb/releases/download/mosdns/mosdns-linux-${arch}.zip"
+        log "使用标准版本"
+    fi
+    
+    log "开始下载 MosDNS 核心：$MOSDNS_URL"
+
+    if ! curl -L -o /tmp/mosdns.zip "$MOSDNS_URL"; then
+        log "MosDNS 下载失败，请检查网络连接"
+        exit 1
+    fi
+
+    log "MosDNS 下载完成，开始安装..."
+    if ! unzip -o /tmp/mosdns.zip -d /usr/local/bin; then
+        log "解压 MosDNS 失败，请检查压缩包完整性"
+        exit 1
+    fi
+
+    chmod +x /usr/local/bin/mosdns || log "警告：未能设置 MosDNS 执行权限"
+    rm -f /tmp/mosdns.zip
+    
+    # 显示安装完成的版本信息
+    new_version=$(/usr/local/bin/mosdns version 2>/dev/null | head -n1 | awk '{print $2}' || echo "未知版本")
+    log "MosDNS 安装完成，版本：$new_version，临时文件已清理"
+}
+
+# 主逻辑
+log "开始更新 MosDNS..."
+
+# 安装核心
+mosdns_install
+
+# 重启 MosDNS 服务
+log "正在通过 Supervisor 重启 MosDNS 服务..."
+if supervisorctl restart mosdns; then
+    log "MosDNS 服务重启成功。"
 else
-    echo "[$(date)] 设置执行权限失败，请检查文件路径和权限设置。"
+    log "MosDNS 服务重启失败，请检查 Supervisor 配置。"
     exit 1
 fi
 
 # 清理临时文件
 rm -rf /tmp/*
 
-# 重启 MosDNS 服务
-echo "[$(date)] 正在通过 Supervisor 重启 MosDNS 服务..."
-if supervisorctl restart mosdns; then
-    echo "[$(date)] MosDNS 服务重启成功。"
-else
-    echo "[$(date)] MosDNS 服务重启失败，请检查 Supervisor 配置。"
-    exit 1
-fi
-
-# 更新完成日志
-echo "[$(date)] MosDNS 更新并重启成功。"
+log "MosDNS 更新并重启成功。"

--- a/watch/update_sb.sh
+++ b/watch/update_sb.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-# 定义颜色变量
+# 颜色变量
 yellow="\033[33m"
-green="\033[32m"
 reset="\033[0m"
 
+# 日志函数
 log() {
-    echo -e "[$(date +'%F %T')] $*"
+    echo -e "[$(date +'%F %T')] ${yellow}$*${reset}"
 }
 
-# 检测系统 CPU 架构
+# 检测系统架构
 detect_architecture() {
     case "$(uname -m)" in
         x86_64)     echo "amd64" ;;
@@ -19,10 +19,53 @@ detect_architecture() {
         s390x)      echo "s390x" ;;
         i386|i686)  echo "386" ;;
         *)
-            echo -e "${yellow}不支持的CPU架构: $(uname -m)${reset}"
+            log "不支持的CPU架构: $(uname -m)"
             exit 1
             ;;
     esac
+}
+
+# 检查 AMD64 架构是否支持 v3 指令集 (x86-64-v3)
+check_amd64_v3_support() {
+    local arch
+    arch=$(detect_architecture)
+
+    # 只有 AMD64 架构才需要检查 v3 支持
+    if [ "$arch" != "amd64" ]; then
+        return 1
+    fi
+
+    # v3 要求的指令集
+    local required_flags=("sse4_2" "avx" "avx2" "bmi1" "bmi2" "fma" "abm")
+
+    # 获取 CPU flags
+    local cpu_flags
+    cpu_flags=$(grep -m1 -o -E 'sse4_2|avx2|avx|bmi1|bmi2|fma|abm' /proc/cpuinfo | sort -u)
+
+    # 检查每一个必须的指令集
+    for flag in "${required_flags[@]}"; do
+        if ! grep -qw "$flag" <<< "$cpu_flags"; then
+            log "AMD64 架构缺少指令集: $flag → 不支持 v3"
+            return 1
+        fi
+    done
+
+    log "检测到 AMD64 架构支持完整 v3 指令集"
+    return 0
+}
+
+# 加载环境变量
+load_env() {
+    local env_file="/mssb/mssb.env"
+    if [ -f "$env_file" ]; then
+        # shellcheck source=/mssb/mssb.env
+        source "$env_file"
+        log "已加载环境变量文件 $env_file"
+    else
+        log "未找到环境变量文件 $env_file，使用默认配置"
+        amd64v3_enabled="false"
+        singbox_core_type="reF1nd"
+    fi
 }
 
 # 智能检测 Sing-box 核心类型和版本
@@ -31,8 +74,11 @@ detect_singbox_info() {
     version_output=$(/usr/local/bin/sing-box version 2>/dev/null | head -n1)
     current_version=$(echo "$version_output" | awk '{print $3}' || echo "未知版本")
 
-    # 优先从文件获取核心类型，如果文件不存在则从命令输出智能识别
-    if [ -f "/mssb/.core_type" ]; then
+    # 优先从环境变量获取核心类型
+    if [ -n "$singbox_core_type" ]; then
+        core_type="sing-box-$singbox_core_type"
+        detection_source="环境变量"
+    elif [ -f "/mssb/.core_type" ]; then
         core_type=$(cat "/mssb/.core_type")
         detection_source="类型文件/mssb/.core_type"
     else
@@ -49,27 +95,38 @@ detect_singbox_info() {
 
     # 输出检测结果
     log "当前安装的版本: $current_version"
-    log "当前安装的版本: (核心类型：$core_type，来源：$detection_source)"
+    log "当前核心类型: $core_type (来源：$detection_source)"
 }
 
-# 主体流程
-main() {
-    log "开始更新 Sing-box..."
-
+# 安装 Sing-box 核心
+singbox_install() {
+    # 加载环境变量
+    load_env
+    
     # 获取当前核心类型
     detect_singbox_info
 
     arch=$(detect_architecture)
     
-    # 根据核心类型选择下载地址
+    # 根据核心类型和 v3 支持情况选择下载地址
     case "$core_type" in
         "sing-box-reF1nd")
-            SING_BOX_URL="https://github.com/herozmy/StoreHouse/releases/download/sing-box-reF1nd/sing-box-reF1nd-dev-linux-${arch}.tar.gz"
-            log "当前使用 reF1nd佬 R核心，准备更新..."
+            if [ "$amd64v3_enabled" = "true" ] && check_amd64_v3_support; then
+                SING_BOX_URL="https://github.com/baozaodetudou/mssb/releases/download/sing-box-reF1nd/sing-box-reF1nd-dev-linux-amd64v3.tar.gz"
+                log "使用 reF1nd佬 R核心 AMD64 v3 优化版本"
+            else
+                SING_BOX_URL="https://github.com/baozaodetudou/mssb/releases/download/sing-box-reF1nd/sing-box-reF1nd-dev-linux-${arch}.tar.gz"
+                log "使用 reF1nd佬 R核心标准版本"
+            fi
             ;;
         "sing-box-yelnoo")
-            SING_BOX_URL="https://github.com/herozmy/StoreHouse/releases/download/sing-box-yelnoo/sing-box-yelnoo-linux-${arch}.tar.gz"
-            log "当前使用 S佬Y核心，准备更新..."
+            if [ "$amd64v3_enabled" = "true" ] && check_amd64_v3_support; then
+                SING_BOX_URL="https://github.com/baozaodetudou/mssb/releases/download/sing-box-yelnoo/sing-box-yelnoo-dev-linux-amd64v3.tar.gz"
+                log "使用 S佬Y核心 AMD64 v3 优化版本"
+            else
+                SING_BOX_URL="https://github.com/baozaodetudou/mssb/releases/download/sing-box-yelnoo/sing-box-yelnoo-dev-linux-${arch}.tar.gz"
+                log "使用 S佬Y核心标准版本"
+            fi
             ;;
         *)
             log "未知的核心类型：$core_type，退出更新"
@@ -77,29 +134,32 @@ main() {
             ;;
     esac
 
-    log "正在从 $SING_BOX_URL 下载 Sing-box..."
-    if wget -O /tmp/sing-box.tar.gz "$SING_BOX_URL"; then
-        log "Sing-box 下载成功。"
-    else
-        log "Sing-box 下载失败，请检查网络连接或 URL 是否正确。"
+    log "开始下载 Sing-box 核心：$SING_BOX_URL"
+    if ! wget -O /tmp/sing-box.tar.gz "$SING_BOX_URL"; then
+        log "Sing-box 下载失败，请检查网络连接"
         exit 1
     fi
 
-    log "正在解压 Sing-box..."
-    if tar -zxvf /tmp/sing-box.tar.gz -C /usr/local/bin; then
-        log "Sing-box 解压成功。"
-    else
-        log "Sing-box 解压失败，请检查压缩包是否正确。"
+    log "Sing-box 下载完成，开始安装..."
+    if ! tar -zxvf /tmp/sing-box.tar.gz -C /usr/local/bin; then
+        log "解压 Sing-box 失败，请检查压缩包完整性"
         exit 1
     fi
 
-    log "设置 Sing-box 可执行权限..."
-    if chmod +x /usr/local/bin/sing-box; then
-        log "设置执行权限成功。"
-    else
-        log "设置执行权限失败，请检查文件路径和权限。"
-        exit 1
-    fi
+    chmod +x /usr/local/bin/sing-box || log "警告：未能设置 Sing-box 执行权限"
+    rm -f /tmp/sing-box.tar.gz
+    
+    # 显示安装完成的版本信息
+    new_version=$(/usr/local/bin/sing-box version 2>/dev/null | head -n1 | awk '{print $3}' || echo "未知版本")
+    log "Sing-box 安装完成，版本：$new_version，临时文件已清理"
+}
+
+# 主体流程
+main() {
+    log "开始更新 Sing-box..."
+
+    # 安装核心
+    singbox_install
 
     # 更新 UI
     log "准备更新 UI..."
@@ -124,7 +184,7 @@ main() {
 
     # 清理临时文件
     rm -rf /tmp/*
-    log "${green}Sing-box 更新完成，临时文件已清理。${reset}"
+    log "Sing-box 更新完成，临时文件已清理。"
 }
 
 # 执行主函数


### PR DESCRIPTION
dev

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors Mihomo, MosDNS, and Sing-box updater scripts to load env config, optionally use x86-64-v3 builds, switch to new release URLs, and improve logging/version reporting; minor logging tweak in install.sh.
> 
> - **Watch scripts (core updaters)**:
>   - Add AMD64 v3 capability check and opt-in via `amd64v3_enabled` in `/mssb/mssb.env`.
>   - Switch downloads to `baozaodetudou/mssb` with conditional `*-amd64v3` artifacts; keep arch detection.
>   - Load env (`/mssb/mssb.env`), unify colored logging, report installed versions, and clean temp files.
>   - `watch/update_sb.sh`: prioritize `singbox_core_type` from env; detect/reconcile core type; select reF1nd/yelnoo URLs; refactor install flow and restart logic.
>   - `watch/update_mosdns.sh` and `watch/update_mihomo.sh`: refactor install logic, conditional URLs, and restart via Supervisor/systemd.
> - **install.sh**:
>   - Enable escape sequences in `log` output (`echo -e`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95c4d3135dd7fc6418e514341b2a33552eab0150. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->